### PR TITLE
Implement image filter for dark mode

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -39,3 +39,7 @@ body.quarto-dark img.img-fluid.figure-img {
     filter: invert(1) hue-rotate(180deg);
     mix-blend-mode: screen;
 }
+
+body.quarto-dark div.enlarge-image:hover {
+    background-color: var(--quarto-body-bg);
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -34,3 +34,8 @@
   border-bottom: 2px solid #ddd;
   border-top: 2px solid #ddd;
 }
+
+body.quarto-dark img.img-fluid.figure-img {
+    filter: invert(1) hue-rotate(180deg);
+    mix-blend-mode: screen;
+}

--- a/styles.css
+++ b/styles.css
@@ -39,3 +39,7 @@ body.quarto-dark img.img-fluid.figure-img {
     filter: invert(1) hue-rotate(180deg);
     mix-blend-mode: screen;
 }
+
+body.quarto-dark div.enlarge-image:hover {
+    background-color: var(--quarto-body-bg);
+}

--- a/styles.css
+++ b/styles.css
@@ -34,3 +34,8 @@
   border-bottom: 2px solid #ddd;
   border-top: 2px solid #ddd;
 }
+
+body.quarto-dark img.img-fluid.figure-img {
+    filter: invert(1) hue-rotate(180deg);
+    mix-blend-mode: screen;
+}


### PR DESCRIPTION
Changes the images and flips them when in dark mode such that they are visible. 

Before:
![image](https://github.com/user-attachments/assets/88ec1deb-7a1e-4df6-a271-d20d49e69980)

After:
![image](https://github.com/user-attachments/assets/f64891af-9141-448b-915d-5e4acb24556d)

Note: this does apply to Jamovi screenshots, and although it doesn't make it completely unusable it's not ideal. I am thinking of adding classes on all Jamovi images so they do not have this effect—however I think it's a useful addition nevertheless. 